### PR TITLE
Fix link to jsErrLog Service

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ What is this?
 -------------
 jsErrLog is a simple JavaScript script that catches your in-browser
 JavaScript errors and posts them to the
-[jsErrLog Service](jserrlog.appspot.com). This enables you to always be on
+[jsErrLog Service](http://jserrlog.appspot.com). This enables you to always be on
 top of your JavaScript errors.
 
 jsErrLog Service Homepage and demo site: http://jserrlog.appspot.com


### PR DESCRIPTION
The link to jsErrLog Service was broken - now fixed.
