### PR TITLE
< IE 9 support for Queries, Whitelisting & unique guid/visit

### DIFF
--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -36,6 +36,8 @@ if (!window.jsErrLog) {
     // set to false to log errors but pass them through to the default handler
     // (and see them in the browser's error console)
     jsErrLog.trapErrors = true;
+    // log errrors to browser console
+    jsErrLog.logToConsole = false;
 
 	// used internally for testing to know if test succeeded or not
 	jsErrLog._had_errors = false;
@@ -129,15 +131,18 @@ function parseURL(url)
 }
 
 // Respond to an error being raised in the javascript
-jsErrLog.ErrorTrap = function(msg, file_loc, line_no, col_no) {
-	// Is we are debugging on the page then display the error details
-	if(jsErrLog.debugMode) {
-		jsErrLog.error_msg = "Error found in page: " + file_loc +
+jsErrLog.ErrorTrap = function (msg, file_loc, line_no, col_no) {
+    jsErrLog.error_msg = "Error found in page: " + file_loc +
 		                     "\nat line number:" + line_no +
 		                     "\nError Message:" + msg;
-		if (jsErrLog.info != "") {
-			jsErrLog.error_msg += "\nInformation:" + jsErrLog.info;
-		}
+    if (jsErrLog.info != "") {
+        jsErrLog.error_msg += "\nInformation:" + jsErrLog.info;
+    }
+    if (jsErrLog.logToConsole) {
+        console.log(jsErrLog.error_msg);
+    }
+	// Is we are debugging on the page then display the error details
+	if(jsErrLog.debugMode) {
 		alert("jsErrLog caught an error\n--------------\n" + jsErrLog.error_msg);
 	} else {
 		jsErrLog.err_i = jsErrLog.err_i + 1;

--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -129,7 +129,7 @@
 	// default the qsIgnore to nothing (ie pass everything on the querystring)
 	jsErrLog.qsIgnore = new Array();
 	// default ignored domains to nothing
-	jsErrLog.domainBlacklist = new Array();
+	jsErrLog.domainIgnore = new Array();
 	// whitelist script domains which can trigger errors
 	jsErrLog.domainWhitelist = new Array();
 	// max number of reports sent from a page (defaults to 10, false allows infinite)
@@ -212,8 +212,8 @@
 			}
 		}
 		
-		if (jsErrLog.domainBlacklist.length > 0) {	
-			if (jsErrUtils.matchDomains(file_loc,jsErrLog.domainBlacklist) === true){
+		if (jsErrLog.domainIgnore.length > 0) {	
+			if (jsErrUtils.matchDomains(file_loc,jsErrLog.domainIgnore) === true){
 				console.log("jsErrLog - report ignored because " + file_loc + " matched the blacklist" );
 				return;
 			}

--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -30,14 +30,14 @@ if (!window.jsErrLog) {
 	// default the qsIgnore to nothing (ie pass everything on the querystring)
 	jsErrLog.qsIgnore = new Array();
 	// default ignored domains to nothing
-    jsErrLog.domainIgnore = new Array();
+	jsErrLog.domainIgnore = new Array();
 	// max number of reports sent from a page (defaults to 10, -1 allows infinite)
-    jsErrLog.maxRep = 10;
-    // set to false to log errors but pass them through to the default handler
-    // (and see them in the browser's error console)
-    jsErrLog.trapErrors = true;
-    // log errrors to browser console
-    jsErrLog.logToConsole = false;
+	jsErrLog.maxRep = 10;
+	// set to false to log errors but pass them through to the default handler
+	// (and see them in the browser's error console)
+	jsErrLog.trapErrors = true;
+	// log errrors to browser console
+	jsErrLog.logToConsole = false;
 
 	// used internally for testing to know if test succeeded or not
 	jsErrLog._had_errors = false;
@@ -210,12 +210,15 @@ jsErrLog.ErrorTrap = function (msg, file_loc, line_no, col_no) {
 					newFL += newFL == ("") ? "?" + strKey + "=" + objURL[strKey] : "&" + strKey + "=" + objURL[strKey];
 				};
 				if (newFL != "") {
+					if (newFL.length > 2000) {
+						newFL = newFL.substring(0, 2000);
+					}
 					file_loc = fl.protocol + fl.host + fl.pathname;
 					file_loc += fl.search != ("") ? newFL : "";
 					file_loc += fl.hash != ("") ? fl.hash : "";
 				}
 			}
-	    }
+		}
 		
 		// format the data for the request
 		var src = jsErrLog.url + "?i=" + jsErrLog.err_i;

--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -5,7 +5,7 @@
 //  Trap javascript errors on a webpage and re-direct them to a remote logging service
 //  which can then be used to identify and resolve issues without impacting user experience
 //
-//  v1.4.2: domainIgnore adds prefix ignore on file location
+//  v1.4.2: domainBlacklist adds prefix ignore on file location
 //  v1.4.1: added support for colNo in browsers that support it (IE10, Chrome30)
 //  v1.4.0: limit initialization to one instance, escape FL and ERR parameter, limit reports sent
 //  v1.3.0: add support for jsErrLog.qsignore parameter
@@ -14,13 +14,111 @@
 //  v1.0.0: Original
 ///////////////////////////////////////////////////////////////////////////////
 
-if (!window.jsErrLog) {
-	window.jsErrLog = { };
+(function(window) {
 
+	if (window.jsErrLog) return;
+
+	//Support for Array.indexOf in older browsers IE 8 & lower | < ECMAScript 5th Edition
+	if( !Array.prototype.indexOf )
+	{
+		Array.prototype.indexOf = function( element ){
+            for( var i=0, ilen=this.length; i<ilen; i++ ){
+            	if( this[i] == element ) return i;
+            }
+            return -1;
+		};        
+	}
+	
+	window.jsErrLog = {}; //Global
+	var jsErrUtils	= {}; //Local
+
+	//jsErrUtils definitions
+
+	// Generate guid
+	jsErrUtils.generateGuid = function() {
+		return 'aaaaaaaa-aaaa-4aaa-baaa-aaaaaaaaaaaa'.replace(/[ab]/g, function(ch) { 
+			var digit = Math.random()*16|0, newch = ch == 'a' ? digit : (digit&0x3|0x8); 
+			return newch.toString(16); 
+		}).toUpperCase();
+	};
+	
+	// Needed to break the URL up if we want to ignore parameters
+	jsErrUtils.parseURL = function(url) {
+	
+	    // save the unmodified url to "href" property so
+	    // the returned object matches the built-in location object
+	    var locn = { 'href' : url };
+	
+	    // split the URL components
+	    var urlParts = url.replace('//', '/').split('/');
+	
+	    //store the protocol and host
+	    locn.protocol = urlParts[0];
+	    
+	    if (urlParts.length > 1 ) {
+	    
+		    locn.host = urlParts[1];
+		
+		    //extract port number from the host
+		    urlParts[1] = urlParts[1].split(':');
+		    locn.hostname = urlParts[1][0];
+		    locn.port = urlParts[1].length > 1 ? urlParts[1][1] : '';
+		
+		    //splice and join the remainder to get the pathname
+		    urlParts.splice(0, 2);
+		    locn.pathname = '/' + urlParts.join('/');
+		
+		    //extract hash
+		    locn.pathname = locn.pathname.split('#');
+		    locn.hash = locn.pathname.length > 1 ? '#' + locn.pathname[1] : '';
+		    locn.pathname = locn.pathname[0];
+		
+		    // extract search query
+		    locn.pathname = locn.pathname.split('?');
+		    locn.search = locn.pathname.length > 1 ? '?' + locn.pathname[1] : '';
+		    locn.pathname = locn.pathname[0];
+	
+	    }
+	    
+	    return locn;
+	}
+	
+	jsErrUtils.matchDomains = function( loc, domains ) {
+		return (new RegExp( "(" + domains.join('|').replace(/\./g,'\\.').replace(/\*/g,'\\w+') + ")" )).test( loc );		
+	}
+	
+	jsErrUtils.stripQueries = function( loc ) {
+		var queries = {};
+		// Use the String::replace method to iterate over each
+		// name-value pair in the query string.
+		loc.search.replace(
+		new RegExp( "([^?=&]+)(=([^&]*))?", "g" ),
+		// For each matched query string pair, add that
+		// pair to the URL struct using the pre-equals
+		// value as the key.
+			function( $0, $1, $2, $3 ){
+				// Only if the key is NOT in the ignore list should we pick it up
+				if (jsErrLog.qsIgnore.indexOf($1.toLowerCase()) == -1) {
+					queries[ $1 ] = $3;
+				}
+			}
+		);
+		
+		var search = "";
+		for (var key in queries) {
+			search += ( search.length === 0 ? "?" : "&" ) + key + "=" + queries[key];
+		};
+
+		// Rebuild the url
+		return 	( loc.protocol + loc.host + loc.pathname )
+			+	( loc.search != ("") ? search : "" )
+			+	( loc.hash != ("") ? loc.hash : "" );
+	}
+	
+	//jsErrLog definitions
+	
 	// default to debugging off
 	jsErrLog.debugMode = false;
-	// default error message to blank
-	jsErrLog.error_msg = "";
 	// default the index for the message to 0 in case there is more than one
 	jsErrLog.err_i = 0;
 	// default the additional info message to blank
@@ -30,19 +128,26 @@ if (!window.jsErrLog) {
 	// default the qsIgnore to nothing (ie pass everything on the querystring)
 	jsErrLog.qsIgnore = new Array();
 	// default ignored domains to nothing
-	jsErrLog.domainIgnore = new Array();
-	// max number of reports sent from a page (defaults to 10, -1 allows infinite)
+	jsErrLog.domainBlacklist = new Array();
+	// whitelist script domains which can trigger errors
+	jsErrLog.domainWhitelist = new Array();
+	// max number of reports sent from a page (defaults to 10, false allows infinite)
 	jsErrLog.maxRep = 10;
-	// set to false to log errors but pass them through to the default handler
+	// set to false to log errors and also pass them through to the default handler
 	// (and see them in the browser's error console)
-	jsErrLog.trapErrors = true;
+	jsErrLog.trapErrors = false;
 	// log errrors to browser console
 	jsErrLog.logToConsole = false;
 	// Skip CrossOrigin errors. These supply no helpful debugging info, and because
 	// of JavaScript injection from a (possibly ill-behaved) browser plugin, these can't
 	// be controlled from the app side.
 	jsErrLog.ignoreCrossOriginErrors = false;
-
+	// Use a unique guid for every error
+	// default every error on 1 page uses the same guid
+	jsErrLog.uniqueGuid = true;
+	// Generate guid for page session
+	jsErrLog.guid = jsErrUtils.generateGuid();
+	
 	// used internally for testing to know if test succeeded or not
 	jsErrLog._had_errors = false;
 
@@ -51,220 +156,136 @@ if (!window.jsErrLog) {
 	jsErrLog.fnPreviousOnErrorHandler = window.onerror; 
 	// - attach our error handler
 	window.onerror = function(msg, file_loc, line_no, col_no){
-		jsErrLog.ErrorTrap(msg, file_loc, line_no, col_no);
+		jsErrLog.errorTrap(msg, file_loc, line_no, col_no);
 		if(typeof(jsErrLog.fnPreviousOnErrorHandler) == "function") {
 			// process any existing onerror handler 
 			jsErrLog.fnPreviousOnErrorHandler(msg, file_loc, line_no, col_no);
 		}
-        return !jsErrLog.trapErrors;
+        return jsErrLog.trapErrors;
 	}
-}
 
-jsErrLog.appendScript = function(index, src) {
-	try {
-		var script = document.createElement("script");
-		script.id = "script" + index;
-		script.src = src;
-		script.type = "text/javascript";
-
-		var head = document.getElementsByTagName("head")[0];
-		head.appendChild(script);
-	}
-	catch (e) {
-		jsErrLog.ErrorHandler("appendScript", e);
-	}
-};
-
-jsErrLog.removeScript = function(index) {
-	try {
-		var script = document.getElementById("script" + index);
-		var head = document.getElementsByTagName("head")[0];
-		head.removeChild(script);
-	}
-	catch (e) {
-		jsErrLog.ErrorHandler("removeScript", e);
-	}
-};
-
-jsErrLog.ErrorHandler = function(source, error) {
-  jsErrLog._had_errors = true;
-	alert("jsErrLog encountered an unexpected error.\n\nSource: " + source + "\nDescription: " + error.description); 
-};
-
-jsErrLog.guid = function() { // http://www.ietf.org/rfc/rfc4122.txt section 4.4
-	return 'aaaaaaaa-aaaa-4aaa-baaa-aaaaaaaaaaaa'.replace(/[ab]/g, function(ch) { 
-		var digit = Math.random()*16|0, newch = ch == 'a' ? digit : (digit&0x3|0x8); 
-		return newch.toString(16); 
-		}).toUpperCase();
-}
-
-// Needed to break the URL up if we want to ignore parameters
-function parseURL(url) {
-
-    // save the unmodified url to "href" property so
-    // the returned object matches the built-in location object
-    var locn = { 'href' : url };
-
-    if (typeof url == "undefined" || url == "") {
-        return locn;
-    }
-
-    // split the URL components
-    var urlParts = url.replace('//', '/').split('/');
-
-    //store the protocol and host
-    locn.protocol = urlParts[0];
-    if (urlParts.length <=1 ) {
-        return locn;
-    }
-    locn.host = urlParts[1];
-
-    //extract port number from the host
-    urlParts[1] = urlParts[1].split(':');
-    locn.hostname = urlParts[1][0];
-    locn.port = urlParts[1].length > 1 ? urlParts[1][1] : '';
-
-    //splice and join the remainder to get the pathname
-    urlParts.splice(0, 2);
-    locn.pathname = '/' + urlParts.join('/');
-
-    //extract hash
-    locn.pathname = locn.pathname.split('#');
-    locn.hash = locn.pathname.length > 1 ? '#' + locn.pathname[1] : '';
-    locn.pathname = locn.pathname[0];
-
-    // extract search query
-    locn.pathname = locn.pathname.split('?');
-    locn.search = locn.pathname.length > 1 ? '?' + locn.pathname[1] : '';
-    locn.pathname = locn.pathname[0];
-
-    return locn;
-}
-
-// Respond to an error being raised in the javascript
-jsErrLog.ErrorTrap = function (msg, file_loc, line_no, col_no) {
-    jsErrLog.error_msg = "Error found in page: " + file_loc +
-		                     "\nat line number:" + line_no +
-		                     "\nError Message:" + msg;
-    if (jsErrLog.info != "") {
-        jsErrLog.error_msg += "\nInformation:" + jsErrLog.info;
-    }
-    if (jsErrLog.logToConsole) {
-        console.log(jsErrLog.error_msg);
-    }
-	// Is we are debugging on the page then display the error details
-	if(jsErrLog.debugMode) {
-		alert("jsErrLog caught an error\n--------------\n" + jsErrLog.error_msg);
-	} else {
-		jsErrLog.err_i = jsErrLog.err_i + 1;
-
-		// if there are parameters we need to ignore on the querystring strip them off
-		var sn = document.URL;
-		if (jsErrLog.qsIgnore.length > 0) {
-		    var objURL = new Object();
-		    // make sure the qsIgnore array is lower case
-		    var len = jsErrLog.qsIgnore.length;
-			for (var i=0; i<len; i++) {
-				jsErrLog.qsIgnore[i] = jsErrLog.qsIgnore[i].toLowerCase();
-			}
- 
-			// Use the String::replace method to iterate over each
-			// name-value pair in the query string.
-			window.location.search.replace(
-			new RegExp( "([^?=&]+)(=([^&]*))?", "g" ),
-			// For each matched query string pair, add that
-			// pair to the URL struct using the pre-equals
-			// value as the key.
-				function( $0, $1, $2, $3 ){
-					// Only if the key is NOT in the ignore list should we pick it up
-					if (jsErrLog.qsIgnore.indexOf($1.toLowerCase()) == -1) {
-						objURL[ $1 ] = $3;
-					}
-				}
-			);
-			var newSearch = "";
-			for (var strKey in objURL) {
-				newSearch += newSearch == ("") ? "?" + strKey + "=" + objURL[strKey] : "&" + strKey + "=" + objURL[strKey];
-			};
-
-			// Rebuild the new "sn" parameter containing the sanitized version of the querystring
-			sn = window.location.protocol + window.location.host + window.location.pathname;
-			sn += window.location.search != ("") ? newSearch : "";
-			sn += window.location.hash != ("") ? window.location.hash : "";
-
-			// now repeat the process for the fileloc, if it exists 
-			// (in some cases, like an explicitly thrown exception, fileloc might be empty)
-			if (typeof file_loc != "undefined" && file_loc.length > 1) {
-				var fl = parseURL(file_loc);
-				objURL = new Object();
-				fl.search.replace(
-					new RegExp("([^?=&]+)(=([^&]*))?", "g"),
-					// For each matched query string pair, add that
-					// pair to the URL struct using the pre-equals
-					// value as the key.
-					function($0, $1, $2, $3) {
-						// Only if the key is NOT in the ignore list should we pick it up
-						if (jsErrLog.qsIgnore.indexOf($1.toLowerCase()) == -1) {
-							objURL[$1] = $3;
-						}
-					}
-				);
-				var newFL = "";
-				for (var strKey in objURL) {
-					newFL += newFL == ("") ? "?" + strKey + "=" + objURL[strKey] : "&" + strKey + "=" + objURL[strKey];
-				};
-				if (newFL != "") {
-					if (newFL.length > 2000) {
-						newFL = newFL.substring(0, 2000);
-					}
-					file_loc = fl.protocol + fl.host + fl.pathname;
-					file_loc += fl.search != ("") ? newFL : "";
-					file_loc += fl.hash != ("") ? fl.hash : "";
-				}
+	//Append the script to head, calling your error logger
+	jsErrLog.appendScript = function(index, src) {
+		try {
+			var script 	= document.createElement("script"),
+				head 	= document.getElementsByTagName("head")[0];
+				
+			script.id = "script" + index;
+			script.src = src;
+			script.type = "text/javascript";
+			
+			head.appendChild(script);
+		} catch (e) {
+			jsErrLog.errorHandler("appendScript", e);
+		}
+	};
+	
+	//Hide the log call, this won't remove the Javascript completely but it'll remove it from the HTML
+	jsErrLog.removeScript = function(index) {
+		try {
+			var script	= document.getElementById("script" + index),
+				head 	= document.getElementsByTagName("head")[0];
+			head.removeChild(script);
+		} catch (e) {
+			jsErrLog.errorHandler("removeScript", e);
+		}
+	};
+	
+	//Error handler to catch the removeScript & appendScript errors
+	jsErrLog.errorHandler = function(source, error) {
+		jsErrLog._had_errors = true;
+		
+		var message = "jsErrLog encountered an unexpected error.\n\nSource: " + source + "\nDescription: " + error.description;
+		if (jsErrLog.debugMode) alert( message );
+		else					console.log( message );
+	};
+	
+	// Respond to an error being raised in the javascript
+	jsErrLog.errorTrap = function (msg, file_loc, line_no, col_no) {
+	    
+		//When a whitelist exists only trigger errors from script coming from those domains
+		if (jsErrLog.domainWhitelist.length > 0) {	
+			if (jsErrUtils.matchDomains(file_loc,jsErrLog.domainWhitelist) === false){
+				console.log("jsErrLog - report ignored because " + file_loc + " did not match the whitelist" );
+				return;
 			}
 		}
 		
-		// format the data for the request
-		var src = jsErrLog.url + "?i=" + jsErrLog.err_i;
-		src += "&sn=" + escape(sn);
-		src += "&fl=" + escape(file_loc);
-		src += "&ln=" + line_no;
-		src += "&cn="; 
-		src += (typeof col_no === "undefined") ? "" : col_no;
-		src += "&ui=" + jsErrLog.guid();
-		if (jsErrLog.info != "") {
-			src += "&info=" + escape(jsErrLog.info.substr(0, 512));
-        }
-        src += "&err=" + escape(msg.substr(0, 1792-src.length));
-
-		// check that the fl domain/prefix doesn't match anything in the domainIgnore array
-	    var ignore = false;
-	    var ignoreFL = file_loc.toLowerCase();
-	    len = jsErrLog.domainIgnore.length;
-		for (var i=0; i<len; i++) {
-			if (ignoreFL.substr(0,jsErrLog.domainIgnore[i].length) == jsErrLog.domainIgnore[i].toLowerCase()) {
-				ignore = true;
-				break;
+		if (jsErrLog.domainBlacklist.length > 0) {	
+			if (jsErrUtils.matchDomains(file_loc,jsErrLog.domainBlacklist) === true){
+				console.log("jsErrLog - report ignored because " + file_loc + " matched the blacklist" );
+				return;
 			}
 		}
 		
-		if (ignore) {
-			// the file_loc matched an item we want to ignore
-		    console.log("jsErrLog - report ignored because " + file_loc + " matched domainIgnore list");
-		} else if (jsErrLog.ignoreCrossOriginErrors && msg == "Script Error" && line_no == "0") {
+		if (jsErrLog.ignoreCrossOriginErrors && msg == "Script Error" && line_no == "0") {
 		    console.log("jsErrLog - cross origin script error ignored because no additional error info supplied.");
-		} 
-	        else {
-
+		    return;
+		}
+		
+		var error_msg =	"Error found in page: " + file_loc +
+	                    "\nat line number:" + line_no +
+	                    "\nError Message:" + msg;
+		
+	    if (jsErrLog.info != "") {
+	        error_msg += "\nInformation:" + jsErrLog.info;
+	    }
+	    
+	    if (jsErrLog.logToConsole) {
+	        console.log(error_msg);
+	    }
+	    
+		// Is we are debugging on the page then display the error details
+		if (jsErrLog.debugMode) {
+			alert("jsErrLog caught an error\n--------------\n" + error_msg);
+		} else {
+			jsErrLog.err_i += 1;
+	
+			// if there are parameters we need to ignore on the querystring strip them off
+			var sn = document.URL;
+			if (jsErrLog.qsIgnore.length > 0) {
+			    
+			    // make sure the qsIgnore array is lower case
+				for (var i=0,ilen=jsErrLog.qsIgnore.length; i<ilen; i++) {
+					jsErrLog.qsIgnore[i] = jsErrLog.qsIgnore[i].toLowerCase();
+				}
+	 
+				sn = jsErrUtils.stripQueries( window.location );
+	
+				// now repeat the process for the fileloc, if it exists 
+				// (in some cases, like an explicitly thrown exception, fileloc might be empty)
+				if (typeof file_loc !== "undefined" && file_loc.length > 1) {
+					
+					file_loc = jsErrUtils.stripQueries( jsErrUtils.parseURL(file_loc) );
+					
+				}
+			}
+			
+			// format the data for the request
+			var src = jsErrLog.url + "?i=" + jsErrLog.err_i;
+			src += "&sn=" + escape(sn);
+			src += "&fl=" + escape(file_loc);
+			src += "&ln=" + line_no;
+			src += "&cn="; 
+			src += (typeof col_no === "undefined") ? "" : col_no;
+			src += "&ui=" + ( jsErrLog.uniqueGuid ? jsErrUtils.generateGuid() : jsErrLog.guid );
+			if (jsErrLog.info != "") {
+				src += "&info=" + escape(jsErrLog.info.substr(0, 256));//You should be able to give enough information with 256 chars
+	        }
+	        src += "&err=";
+	        // Keep the path length under 2000 chars which is advised for URL's in browsers 
+	        src += escape(msg.substr(0, 1999-src.length)); 
+	        
 			// and pass the error details to the Async logging sender		
 			// if the jsErrLog.maxRep hasn't tripped
-			if ((jsErrLog.maxRep > 0) || (jsErrLog.maxRep = -1)) {
+			if (jsErrLog.maxRep > 0 || jsErrLog.maxRep === false) {
 				if (jsErrLog.maxRep > 0) {
 				    jsErrLog.maxRep -= 1;
 				}
 				jsErrLog.appendScript(jsErrLog.err_i, src);
 			}
 		}
+		return true;
 	}
-	return true;
-}
+
+})(window);

--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -1,11 +1,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 //
-//  jsErrLog.js         version 1.4.2
+//  jsErrLog.js         version 1.5.0
 //
 //  Trap javascript errors on a webpage and re-direct them to a remote logging service
 //  which can then be used to identify and resolve issues without impacting user experience
-//
-//  v1.4.2: domainBlacklist adds prefix ignore on file location
+//  
+//  v1.5.0: QueryString support <IE9, White- & Blacklist, unique guid/page
+//  v1.4.2: domainIgnore adds prefix ignore on file location
 //  v1.4.1: added support for colNo in browsers that support it (IE10, Chrome30)
 //  v1.4.0: limit initialization to one instance, escape FL and ERR parameter, limit reports sent
 //  v1.3.0: add support for jsErrLog.qsignore parameter

--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -38,6 +38,10 @@ if (!window.jsErrLog) {
 	jsErrLog.trapErrors = true;
 	// log errrors to browser console
 	jsErrLog.logToConsole = false;
+	// Skip CrossOrigin errors. These supply no helpful debugging info, and because
+	// of JavaScript injection from a (possibly ill-behaved) browser plugin, these can't
+	// be controlled from the app side.
+	jsErrLog.ignoreCrossOriginErrors = false;
 
 	// used internally for testing to know if test succeeded or not
 	jsErrLog._had_errors = false;
@@ -247,7 +251,10 @@ jsErrLog.ErrorTrap = function (msg, file_loc, line_no, col_no) {
 		if (ignore) {
 			// the file_loc matched an item we want to ignore
 		    console.log("jsErrLog - report ignored because " + file_loc + " matched domainIgnore list");
-		} else {
+		} else if (jsErrLog.ignoreCrossOriginErrors && msg == "Script Error" && line_no == "0") {
+		    console.log("jsErrLog - cross origin script error ignored because no additional error info supplied.");
+		} 
+	        else {
 
 			// and pass the error details to the Async logging sender		
 			// if the jsErrLog.maxRep hasn't tripped

--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -142,9 +142,10 @@ jsErrLog.ErrorTrap = function(msg, file_loc, line_no, col_no) {
 		// if there are parameters we need to ignore on the querystring strip them off
 		var sn = document.URL;
 		if (jsErrLog.qsIgnore.length > 0) {
-			var objURL = new Object();
- 			// make sure the qsIgnore array is lower case
-			for (var i in jsErrLog.qsIgnore) {
+		    var objURL = new Object();
+		    // make sure the qsIgnore array is lower case
+		    var len = jsErrLog.qsIgnore.length;
+			for (var i=0; i<len; i++) {
 				jsErrLog.qsIgnore[i] = jsErrLog.qsIgnore[i].toLowerCase();
 			}
  
@@ -163,8 +164,8 @@ jsErrLog.ErrorTrap = function(msg, file_loc, line_no, col_no) {
 				}
 			);
 			var newSearch = "";
-			for (var strKey in objURL){
-				newSearch += newSearch == ("") ? "?" + strKey + "=" + objURL[strKey] : "&" + strKey + "=" + objURL[strKey]
+			for (var strKey in objURL) {
+			    newSearch += newSearch == ("") ? "?" + strKey + "=" + objURL[strKey] : "&" + strKey + "=" + objURL[strKey];
 			};
 
 			// Rebuild the new "sn" parameter containing the sanitized version of the querystring
@@ -188,8 +189,8 @@ jsErrLog.ErrorTrap = function(msg, file_loc, line_no, col_no) {
 				}
 			);
 			var newFL = "";
-			for (var strKey in objURL){
-				newFL += newFL == ("") ? "?" + strKey + "=" + objURL[strKey] : "&" + strKey + "=" + objURL[strKey]
+			for (var strKey in objURL) {
+			    newFL += newFL == ("") ? "?" + strKey + "=" + objURL[strKey] : "&" + strKey + "=" + objURL[strKey];
 			};
 			if (newFL != "") {
 				file_loc = fl.protocol + fl.host + fl.pathname;
@@ -206,16 +207,17 @@ jsErrLog.ErrorTrap = function(msg, file_loc, line_no, col_no) {
 		src += "&ln=" + line_no;
 		src += "&cn="; 
 		src += (typeof col_no === "undefined") ? "" : col_no;
-		src += "&err=" + escape(msg.substr(0, 1024));
 		src += "&ui=" + jsErrLog.guid();
 		if (jsErrLog.info != "") {
 			src += "&info=" + escape(jsErrLog.info.substr(0, 512));
-		}
-		
+        }
+        src += "&err=" + escape(msg.substr(0, 1792-src.length));
+
 		// check that the fl domain/prefix doesn't match anything in the domainIgnore array
-		ignore = false
-		ignoreFL = file_loc.toLowerCase()
-		for (var i in jsErrLog.domainIgnore) {
+	    var ignore = false;
+	    var ignoreFL = file_loc.toLowerCase();
+	    len = jsErrLog.domainIgnore.length;
+		for (var i=0; i<len; i++) {
 			if (ignoreFL.substr(0,jsErrLog.domainIgnore[i].length) == jsErrLog.domainIgnore[i].toLowerCase()) {
 				ignore = true;
 				break;
@@ -224,14 +226,14 @@ jsErrLog.ErrorTrap = function(msg, file_loc, line_no, col_no) {
 		
 		if (ignore) {
 			// the file_loc matched an item we want to ignore
-			console.log("jsErrLog - report ignored because " + file_loc + " matched domainIgnore list")
+		    console.log("jsErrLog - report ignored because " + file_loc + " matched domainIgnore list");
 		} else {
 
 			// and pass the error details to the Async logging sender		
 			// if the jsErrLog.maxRep hasn't tripped
 			if ((jsErrLog.maxRep > 0) || (jsErrLog.maxRep = -1)) {
 				if (jsErrLog.maxRep > 0) {
-					jsErrLog.maxRep -= 1
+				    jsErrLog.maxRep -= 1;
 				}
 				jsErrLog.appendScript(jsErrLog.err_i, src);
 			}

--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -32,7 +32,10 @@ if (!window.jsErrLog) {
 	// default ignored domains to nothing
     jsErrLog.domainIgnore = new Array();
 	// max number of reports sent from a page (defaults to 10, -1 allows infinite)
-	jsErrLog.maxRep = 10;
+    jsErrLog.maxRep = 10;
+    // set to false to log errors but pass them through to the default handler
+    // (and see them in the browser's error console)
+    jsErrLog.trapErrors = true;
 
 	// used internally for testing to know if test succeeded or not
 	jsErrLog._had_errors = false;
@@ -47,7 +50,7 @@ if (!window.jsErrLog) {
 			// process any existing onerror handler 
 			jsErrLog.fnPreviousOnErrorHandler(msg, file_loc, line_no, col_no);
 		}
-		return true;
+        return jsErrLog.trapErrors;
 	}
 }
 


### PR DESCRIPTION
Based on fork of https://github.com/mnbeer/jsErrLog

- code optimazation
- indexOf support < IE9
- Object for local functions
- whitelist & blacklist for domains instead of domainIgnore
- removed error_msg from global scope
- maxRep now needs to be false instead of -1 for infinite errors/page
- possibility to have 1 guid/page or 1 guid/error
- errorHandler only alerts when in debugMode and logs it to the console
otherwise, you don't want users to see an alert message
- the URL query stripping is now handled by a general function
- Logger calls now stay below 2000 chars