### PR TITLE
For jsErrLog.url, http: → https:

### DIFF
--- a/src/static/jserrlog.js
+++ b/src/static/jserrlog.js
@@ -125,7 +125,7 @@
 	// default the additional info message to blank
 	jsErrLog.info = "";
 	// default the URL to the appspot service
-	jsErrLog.url = "http://jserrlog.appspot.com/logger.js";
+	jsErrLog.url = "https://jserrlog.appspot.com/logger.js";
 	// default the qsIgnore to nothing (ie pass everything on the querystring)
 	jsErrLog.qsIgnore = new Array();
 	// default ignored domains to nothing


### PR DESCRIPTION
Looks like https://jserrlog.appspot.com/logger.js works fine (with `https`), so updating to use secure URL. Don't want the mixed content warnings when using the script on a `https` site.

Thanks!